### PR TITLE
Fix errors getting public IP details

### DIFF
--- a/lib/rackconnect/models/public_ip.rb
+++ b/lib/rackconnect/models/public_ip.rb
@@ -7,6 +7,6 @@ class Rackconnect::PublicIP
 
   attributes :created, :cloud_server, :id, :public_ip_v4,
     :status, :status_detail, :updated, :configuration_to_cloud_account_uuid,
-    :retain, :failure_core_ticket_uuid
+    :retain, :failure_core_ticket_uuid, :added_by_match_rule
 
 end

--- a/spec/support/public_ip/show.json
+++ b/spec/support/public_ip/show.json
@@ -18,5 +18,7 @@
   "public_ip_v4": "203.0.113.110",
   "status": "ACTIVE",
   "status_detail": null,
-  "updated": "2014-05-30T03:24:18Z"
+  "updated": "2014-05-30T03:24:18Z",
+  "retain": false,
+  "added_by_match_rule": false
 }


### PR DESCRIPTION
By adding the new `added_by_match_rule` public-IP attribute to the PublicIP model.

I was getting this error when calling `Rackconnect::PublicIP.all`:

```
/<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:13:in `block in initialize': undefined method `added_by_match_rule=' for #<Rackconnect::PublicIP:0x000055bcaab1a9d8> (NoMethodError)
    from /<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:12:in `each'
    from /<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:12:in `initialize'
    from /<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:64:in `new'
    from /<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:64:in `block in all'
    from /<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:64:in `map'
    from /<my home dir>/.rvm/gems/ruby-2.6.8@openstack/bundler/gems/rackconnect-264f93a9da88/lib/rackconnect/lib/model.rb:64:in `all'
    from ... <my code that called Rackconnect::PublicIP.all>
```

Adding the `added_by_match_rule` attribute to PublicIP fixed this.

I've also updated the tests to include `added_by_match_rule` and `retain`, as I'm seeing both of these in the API responses I currently get. For example:

```
{
  :json=>{
    "created"=>"2018-03-20T05:37:08.86Z",
    "cloud_server"=>{
      "cloud_network"=>{
        "cidr"=>"<IP address>/22",
        "created"=>"2015-02-19T07:47:04.087Z",
        "name"=>"RC-LB-CLOUD",
        "private_ip_v4"=>"<IP address>",
        "updated"=>"2020-02-27T17:04:26.13Z",
        "id"=>"<looks like a GUID>"
      },
      "created"=>"2018-03-20T05:33:33.08Z",
      "name"=>"admin-db-staging-bandicoot",
      "updated"=>"2021-10-25T02:00:08.51Z",
      "id"=>"<looks like a GUID>"
    },
    "id"=>"<looks like a GUID>",
    "public_ip_v4"=>"<IP address>",
    "status"=>"ACTIVE",
    "status_detail"=>nil,
    "updated"=>"2018-03-20T05:37:58.11Z",
    "retain"=>false,
    "added_by_match_rule"=>false
  }
}
```